### PR TITLE
resolve RangedError Bug

### DIFF
--- a/lib/src/flutter_verification_code.dart
+++ b/lib/src/flutter_verification_code.dart
@@ -31,18 +31,17 @@ class VerificationCode extends StatefulWidget {
 class _VerificationCodeState extends State<VerificationCode> {
   static final List<FocusNode> _listFocusNode = <FocusNode>[];
   final List<TextEditingController> _listControllerText =
-      <TextEditingController>[];
+  <TextEditingController>[];
   List<String> _code = List();
   int _currentIndex = 0;
 
   @override
   void initState() {
-    if (_listFocusNode.isEmpty) {
-      for (var i = 0; i < widget.length; i++) {
-        _listFocusNode.add(FocusNode());
-        _listControllerText.add(TextEditingController());
-        _code.add('');
-      }
+    _listFocusNode.clear();
+    for (var i = 0; i < widget.length; i++) {
+      _listFocusNode.add(FocusNode());
+      _listControllerText.add(TextEditingController());
+      _code.add('');
     }
     super.initState();
   }


### PR DESCRIPTION
this bug occur when create VerificationCode in stateful widget and after created , call Navigation.pop() and again come back to that page.
when VerificationCode created _listController become empty but if it is not first time to create VerificationCode _listFocusNode , is not empty therefor if statement in initState not call and Given that  widget list is not empty we get error when call _listControllerText[index] because _listController is empty and we call its items.
for resolve that , i deleted the if statement in initState() and instead of that inserted _listFocusNode.clear()