### PR TITLE
add filled property to activate fillColor

### DIFF
--- a/lib/src/flutter_verification_code.dart
+++ b/lib/src/flutter_verification_code.dart
@@ -143,6 +143,7 @@ class _VerificationCodeState extends State<VerificationCode> {
 
     final underlinedDecoration = InputDecoration(
       fillColor: widget.fillColor,
+      filled: widget.fillColor != null ? true : false,
       enabledBorder: UnderlineInputBorder(
         borderSide: BorderSide(
           color: widget.underlineUnfocusedColor ?? Colors.grey,
@@ -162,6 +163,7 @@ class _VerificationCodeState extends State<VerificationCode> {
 
     final fullDecoration = InputDecoration(
       fillColor: widget.fillColor,
+      filled: widget.fillColor != null ? true : false,
       enabledBorder: OutlineInputBorder(
         borderSide: BorderSide(
           color: widget.underlineUnfocusedColor ?? Colors.grey,


### PR DESCRIPTION
#31 
Add `filled` property to activate input background color when `fillColor` has a value

documentation: 

> If true the decoration's container is filled with [fillColor](https://api.flutter.dev/flutter/material/InputDecoration/fillColor.html).
>
> When [InputDecorator.isHovering](https://api.flutter.dev/flutter/material/InputDecorator/isHovering.html) is true, the [hoverColor](https://api.flutter.dev/flutter/material/InputDecoration/hoverColor.html) is also blended into the final fill color.
> 
> Typically this field set to true if [border](https://api.flutter.dev/flutter/material/InputDecoration/border.html) is an [UnderlineInputBorder](https://api.flutter.dev/flutter/material/UnderlineInputBorder-class.html).
> 
> The decoration's container is the area which is filled if [filled](https://api.flutter.dev/flutter/material/InputDecoration/filled.html) is true and [border](https://api.flutter.dev/flutter/material/InputDecoration/border.html)ed per the border. It's the area adjacent to [icon](https://api.flutter.dev/flutter/material/InputDecoration/icon.html) and above the widgets that contain [helperText](https://api.flutter.dev/flutter/material/InputDecoration/helperText.html), [errorText](https://api.flutter.dev/flutter/material/InputDecoration/errorText.html), and [counterText](https://api.flutter.dev/flutter/material/InputDecoration/counterText.html).
> 
> This property is false by default.