### PR TITLE
If backspace pressed in empty box, move to previous box

### DIFF
--- a/lib/src/flutter_verification_code.dart
+++ b/lib/src/flutter_verification_code.dart
@@ -185,6 +185,13 @@ class _VerificationCodeState extends State<VerificationCode> {
       focusNode: _listFocusNodeKeyListener[index],
       onKey: (event) {
         if (event.runtimeType == RawKeyUpEvent) {
+          if (event.data.logicalKey == LogicalKeyboardKey.backspace &&
+              _listControllerText[index].text.isEmpty) {
+            if (index > 0) {
+              _listControllerText[index - 1].clear();
+            }
+            _prev(index);
+          }
           if (event.data.logicalKey == LogicalKeyboardKey.arrowLeft) {
             _prev(index);
           } else if (event.data.logicalKey == LogicalKeyboardKey.arrowRight) {


### PR DESCRIPTION
i noticed that if backspace is pressed in a box with a character in it, the character is erased and focus is transferred to the previous box
during editing when a character is entered focus is transferred to the next box - which is empty
if backspace is pressed in the empty box, nothing happens because the onChange function is not triggered by a backspace in an empty text field
i added a check in the onKey of the existing RawKeyboardListener to check if backspace is pressed in an empty box, and move to the previous box